### PR TITLE
Sets the correct simulation time in the MultiLevelLaserscan structure.

### DIFF
--- a/sim/src/sensors/RotatingRaySensor.cpp
+++ b/sim/src/sensors/RotatingRaySensor.cpp
@@ -204,6 +204,7 @@ namespace mars {
       if(full_scan_mlls) {
         full_scan_mlls = false;
         scan = mlls_full;
+        scan.time.microseconds = getTime() * 1000;
         return true;
       } else {
         return false;


### PR DESCRIPTION
Directly sets the simulation time of the MultiLevelLaserscan structure within the MARS sensor.
And converts the milliseconds to microseconds now.
