### PR TITLE
removed simulation/mars/urdf_loader dependency

### DIFF
--- a/app/manifest.xml
+++ b/app/manifest.xml
@@ -5,7 +5,7 @@
 
     <depend package="simulation/mars/scripts/cmake" />
     <depend package="simulation/mars/scene_loader" />
-    <depend package="simulation/mars/urdf_loader" />
+    <!--<depend package="simulation/mars/urdf_loader" />-->
     <depend package="simulation/mars/graphics" />
     <depend package="simulation/mars/sim" />
     <depend package="simulation/lib_manager" />


### PR DESCRIPTION
as the code was removed by https://github.com/rock-simulation/mars/commit/dd83a97a7fffb280ee22b6642716017b8da26451