### PR TITLE
rename motor min/max_val -> min/maxValue

### DIFF
--- a/interfaces/src/MotorData.cpp
+++ b/interfaces/src/MotorData.cpp
@@ -69,8 +69,8 @@ namespace mars {
 //          this->p = other.p;
 //          this->i = other.i;
 //          this->d = other.d;
-//          this->max_val = other.max_val;
-//          this->min_val = other.min_val;
+//          this->maxValue = other.maxValue;
+//          this->minValue = other.minValue;
 //        }
 //    }
 
@@ -87,8 +87,8 @@ namespace mars {
       p = 0;
       i = 0;
       d = 0;
-      max_val = M_PI;
-      min_val = -M_PI;
+      maxValue = M_PI;
+      minValue = -M_PI;
     }
 
     bool MotorData::fromConfigMap(ConfigMap *config,
@@ -131,8 +131,8 @@ namespace mars {
       GET_VALUE("i", i, Double);
       GET_VALUE("d", d, Double);
       GET_VALUE("value", value, Double);
-      GET_VALUE("max_val", max_val, Double);
-      GET_VALUE("min_val", min_val, Double);
+      GET_VALUE("maxValue", maxValue, Double);
+      GET_VALUE("minValue", minValue, Double);
 
       return 1;
     }
@@ -155,8 +155,8 @@ namespace mars {
       SET_VALUE("i", i);
       SET_VALUE("d", d);
       SET_VALUE("value", value);
-      SET_VALUE("max_val", max_val);
-      SET_VALUE("min_val", min_val);
+      SET_VALUE("maxValue", maxValue);
+      SET_VALUE("minValue", minValue);
     }
 
     void MotorData::getFilesToSave(std::vector<std::string> *fileList) {

--- a/interfaces/src/MotorData.h
+++ b/interfaces/src/MotorData.h
@@ -67,14 +67,16 @@ namespace mars {
       sReal p;  // p part of the controller
       sReal i;  // i part of the controller
       sReal d;  // d part of the controller
-      sReal max_val;
-      sReal min_val;
+      sReal maxValue;
+      sReal minValue;
       static std::map<std::string, std::string> legacynames;
 
       static std::map<std::string, std::string> init_legacynames() {
         std::map<std::string, std::string> tmpmap;
         tmpmap["maxEffort"] = "motorMaxForce";
         tmpmap["maxSpeed"] = "maximumVelocity";
+        tmpmap["maxValue"] = "max_val";
+        tmpmap["minValue"] = "min_val";
         return tmpmap;
       }
     }; // end of class MotorData

--- a/sim/src/core/SimMotor.cpp
+++ b/sim/src/core/SimMotor.cpp
@@ -331,10 +331,10 @@ namespace mars {
           switch (sMotor.type) {
           case MOTOR_TYPE_PID:
           {
-            if(desired_position>sMotor.max_val) 
-                desired_position = sMotor.max_val;
-            if(desired_position<sMotor.min_val) 
-                desired_position = sMotor.min_val;
+            if(desired_position>sMotor.maxValue)
+                desired_position = sMotor.maxValue;
+            if(desired_position<sMotor.minValue)
+                desired_position = sMotor.minValue;
             /*
               if(desired_position>2*M_PI) desired_position=0;
               else if(desired_position>M_PI) desired_position=-2*M_PI+desired_position;


### PR DESCRIPTION
Similarly as previously done with maxEffort and maxSpeed, the
MotorData variables min_val and max_val were renamed to minValue
and maxValue in order to create a consistent camelcase naming.

Backwards-compatibility with old MARS scenes was insured by amending
the legacynames map.

As these values are now also exported from Blender, I figured it would be nice and
keep the naming scheme consistent.