### PR TITLE
Throw a error is parsing of a obj files failes

### DIFF
--- a/graphics/src/gui_helper_functions.cpp
+++ b/graphics/src/gui_helper_functions.cpp
@@ -252,6 +252,10 @@ namespace mars {
       nodemanager tempnode;
       bool found = false;
       // check whether it is a osg::Group (.obj file)
+      if(!completeNode.valid()){
+          throw std::runtime_error("cannot read node from file");
+      }
+
       if((myGroupFromRead = completeNode->asGroup()) != 0){
         //go through the read node group and combine the parts of the actually
         //handled node


### PR DESCRIPTION
This is related to: https://github.com/rock-simulation/mars/issues/44
and throw a correct error if something goes wrong