### PR TITLE
Fixed ambigious call to isinf and isnan on c++11

### DIFF
--- a/sim/src/core/SimNode.cpp
+++ b/sim/src/core/SimNode.cpp
@@ -768,6 +768,24 @@ namespace mars {
     }
 
     void SimNode::checkNodeState(void) {
+//Check for c++11 which provides isinf, the isinf call is ambigious otherwise
+#if __cplusplus > 199711L
+      if (std::isnan(sNode.pos.x())) sNode.pos.x() = 0.0;
+      else if (std::isinf(sNode.pos.x())) sNode.pos.x() = 0.0;
+      if (std::isnan(sNode.pos.y())) sNode.pos.y() = 0.0;
+      else if (std::isinf(sNode.pos.y())) sNode.pos.y() = 0.0;
+      if (std::isnan(sNode.pos.z())) sNode.pos.z() = 0.0;
+      else if (std::isinf(sNode.pos.z())) sNode.pos.z() = 0.0;
+      if (std::isnan(sNode.rot.x())) sNode.rot.x() = 0.0;
+      else if (std::isinf(sNode.rot.x())) sNode.rot.x() = 0.0;
+      if (std::isnan(sNode.rot.y())) sNode.rot.y() = 0.0;
+      else if (std::isinf(sNode.rot.y())) sNode.rot.y() = 0.0;
+      if (std::isnan(sNode.rot.z())) sNode.rot.z() = 0.0;
+      else if (std::isinf(sNode.rot.z())) sNode.rot.z() = 0.0;
+      if (std::isnan(sNode.rot.w())) sNode.rot.w() = 1.0;
+      else if (std::isinf(sNode.rot.w())) sNode.rot.w() = 1.0;
+#else
+//Pre c++11
       if (isnan(sNode.pos.x())) sNode.pos.x() = 0.0;
       else if (isinf(sNode.pos.x())) sNode.pos.x() = 0.0;
       if (isnan(sNode.pos.y())) sNode.pos.y() = 0.0;
@@ -782,6 +800,7 @@ namespace mars {
       else if (isinf(sNode.rot.z())) sNode.rot.z() = 0.0;
       if (isnan(sNode.rot.w())) sNode.rot.w() = 1.0;
       else if (isinf(sNode.rot.w())) sNode.rot.w() = 1.0;
+#endif
     }
 
     void SimNode::getContactPoints(std::vector<Vector> *contact_points) const {


### PR DESCRIPTION
Appears on ubuntu 15.10 when rock/mars is compiled with c++11 
