### PR TITLE
Support more mesh file formats

### DIFF
--- a/graphics/src/3d_objects/LoadDrawObject.cpp
+++ b/graphics/src/3d_objects/LoadDrawObject.cpp
@@ -93,9 +93,7 @@ namespace mars {
         geodes.push_back(loadedNode->asGeode());
       }
       // import an .STL file
-      else if((filename.substr(filename.size()-4, 4) == ".STL") ||
-              (filename.substr(filename.size()-4, 4) == ".stl") ||
-              (filename.substr(filename.size()-4, 4) == ".obj")) {
+      else {
         osg::ref_ptr<osg::Node> loadedNode = GuiHelper::readNodeFromFile(filename);
         if(!loadedNode.valid()) {
           std::cerr << "LoadDrawObject: no node loaded" << std::endl;


### PR DESCRIPTION
Current implementations makes a string compare on mesh file suffixes to find out which should be handled. This is not necessary, since for all files (beside bobj) `osgDB::readNodeFile` is called. So let `osgDB::readNodeFile` decide, which files it can handle instead of constraining supported mesh files artificially.
