### PR TITLE
Master deps

### DIFF
--- a/common/graphics/osg_terrain/CMakeLists.txt
+++ b/common/graphics/osg_terrain/CMakeLists.txt
@@ -18,7 +18,9 @@ endif()
 include_directories(src)
 
 pkg_check_modules(PKGCONFIG REQUIRED
-          eigen3
+			    mars_graphics
+			    configmaps
+			    mars_utils
           osg_material_manager
           opencv
 )

--- a/common/graphics/osg_terrain/manifest.xml
+++ b/common/graphics/osg_terrain/manifest.xml
@@ -2,6 +2,8 @@
     <description brief="osg_terrain">
 	</description>
 	<maintainer>Malte Langosz/malte.langosz@dfki.de</maintainer>
+    <depend package="simulation/mars/graphics" />
+    <depend package="tools/configmaps" />
     <depend package="simulation/mars/common/utils" />
     <depend package="simulation/mars/common/graphics/osg_material_manager" />
     <tags>needs_opt</tags>


### PR DESCRIPTION
This reverts commit 69e80d49128b1151fc2a2c41ab65199f0749e405

Looks like they were actual dependencies, but not in the manifest.xml.

When compiling the headers were in the path so i did not notice they are included in the Terrain.cpp :-|