### PR TITLE
Changed wireframe highlighting to osgFX::Outline

### DIFF
--- a/graphics/src/3d_objects/DrawObject.cpp
+++ b/graphics/src/3d_objects/DrawObject.cpp
@@ -72,6 +72,7 @@ namespace mars {
         group_(0),
         posTransform_(0),
         scaleTransform_(0),
+        outlineEffect_(0),
         maxNumLights(1),
         g(g),
         sharedStateGroup(false),
@@ -107,8 +108,18 @@ namespace mars {
       posTransform_ = new osg::PositionAttitudeTransform();
       posTransform_->setPivotPoint(osg::Vec3(pivot_.x(), pivot_.y(), pivot_.z()));
       posTransform_->setPosition(osg::Vec3(0.0, 0.0, 0.0));
-      posTransform_->addChild(scaleTransform_.get());
       posTransform_->setNodeMask(nodeMask_);
+
+      #ifdef USE_OSGFX
+      outlineEffect_ = new osgFX::Outline;
+      outlineEffect_->setWidth(12);
+      outlineEffect_->setColor(osg::Vec4(0,0.75,0,1));
+      outlineEffect_->setEnabled(false);
+      outlineEffect_->addChild(scaleTransform_.get());      
+      posTransform_->addChild(outlineEffect_.get());
+      #else
+      posTransform_->addChild(scaleTransform_.get());
+      #endif
 
       group_ = new osg::Group;
       if(sharedID) {
@@ -271,7 +282,19 @@ namespace mars {
     
     void DrawObject::setSelected(bool val) {
       selected_ = val;
-      if(selectable_) {
+      if (selectable_) {
+        #ifdef USE_OSGFX
+        if (outlineEffect_ == 0) {
+          std::cerr << "No Outline effect created for id " << this->id_ << std::endl;
+        }
+
+        if (selected_ && showSelected) {
+          outlineEffect_->setEnabled(true);
+        } else {
+          outlineEffect_->setEnabled(false);
+        }
+
+        #else
         osg::PolygonMode *polyModeObj;
 
         osg::StateSet *state = group_->getOrCreateStateSet();
@@ -318,6 +341,7 @@ namespace mars {
           state->removeMode(GL_FOG);
 
         }
+        #endif
       }
       for(auto it:selectionChilds) {
         it->setSelected(val);

--- a/graphics/src/3d_objects/DrawObject.h
+++ b/graphics/src/3d_objects/DrawObject.h
@@ -32,6 +32,8 @@
   #warning "DrawObject.h"
 #endif
 
+#define USE_OSGFX
+
 #include <mars/interfaces/MARSDefs.h>
 #include <mars/utils/Vector.h>
 #include <mars/utils/Quaternion.h>
@@ -50,6 +52,9 @@
 #include <osg/Geode>
 #include <osg/LOD>
 #include <osg/Program>
+#ifdef USE_OSGFX
+#include <osgFX/Outline>
+#endif
 
 #include <mars/osg_material_manager/OsgMaterial.h>
 #include <mars/osg_material_manager/MaterialNode.h>
@@ -166,6 +171,9 @@ namespace mars {
       osg::ref_ptr<osg::LOD> lod;
       osg::ref_ptr<osg::PositionAttitudeTransform> posTransform_;
       osg::ref_ptr<osg::MatrixTransform> scaleTransform_;
+      #ifdef USE_OSGFX
+      osg::ref_ptr<osgFX::Outline> outlineEffect_;
+      #endif
       std::vector<DrawObject*> selectionChilds;
       mars::utils::Vector position_, pivot_, geometrySize_, scaledSize_;
       mars::utils::Quaternion quaternion_;

--- a/graphics/src/3d_objects/TerrainDrawObject.cpp
+++ b/graphics/src/3d_objects/TerrainDrawObject.cpp
@@ -103,8 +103,20 @@ namespace mars {
       posTransform_ = new osg::PositionAttitudeTransform();
       //posTransform_->setPivotPoint(osg::Vec3(pivot_.x(), pivot_.y(), pivot_.z()));
       posTransform_->setPosition(osg::Vec3(0.0, 0.0, 0.0));
-      posTransform_->addChild(scaleTransform_.get());
       posTransform_->setNodeMask(nodeMask_);
+
+      #ifdef USE_OSGFX
+      outlineEffect_ = new osgFX::Outline;
+      outlineEffect_->setWidth(12);
+      outlineEffect_->setColor(osg::Vec4(0,0.75,0,1));
+      outlineEffect_->setEnabled(false);
+      outlineEffect_->addChild(scaleTransform_.get());      
+      posTransform_->addChild(outlineEffect_.get());
+      #else
+      posTransform_->addChild(scaleTransform_.get());
+      #endif
+      posTransform_->setNodeMask(nodeMask_);
+
       osg::ref_ptr<osg_terrain::ShaderTerrain> p = new osg_terrain::ShaderTerrain(map);
 
       group_ = new osg::Group;


### PR DESCRIPTION
At the moment, you can switch between Wireframe highlighting and osgFX::Outline usage using #define USE_OSGFX. Maybe you can add it as an option to mars_graphics GUI