### PR TITLE
Update manifest.xml

### DIFF
--- a/plugins/connectors/manifest.xml
+++ b/plugins/connectors/manifest.xml
@@ -8,7 +8,7 @@
     <depend package="simulation/mars/common/data_broker" />
     <depend package="simulation/mars/interfaces" />
     <depend package="simulation/mars/sim" />
-    <depend package="simulation/mars/utils" />
+    <depend package="simulation/mars/common/utils" />
     <depend package="tools/configmaps" />
     <tags>needs_opt</tags>
 </package>


### PR DESCRIPTION
The utils file has been changed from mars/utils to mars/common/utils. The utils file is one of the dependencies of the connector plugin.