### PR TITLE
Fix missing dependencies

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -26,8 +26,26 @@ CMAKE_USE_FULL_RPATH("${CMAKE_INSTALL_PREFIX}/lib")
 
 pkg_check_modules(PKGCONFIG
         lib_manager
+        configmaps
+        # optional but still requires include header to be available if used
+        mars_scene_loader
+        mars_graphics
+        mars_gui
+        mars_sim
+        main_gui
         mars_interfaces
-	configmaps
+        data_broker
+        cfg_manager
+        data_broker_gui
+        cfg_manager_gui
+        lib_manager_gui
+        log_console
+        data_broker_plotter2
+        SkyDomePlugin
+        CameraGUI
+        entity_view
+        mars_smurf
+        mars_smurf_loader
 )
 include_directories(${PKGCONFIG_INCLUDE_DIRS})
 link_directories(${PKGCONFIG_LIBRARY_DIRS})

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -27,25 +27,11 @@ CMAKE_USE_FULL_RPATH("${CMAKE_INSTALL_PREFIX}/lib")
 pkg_check_modules(PKGCONFIG
         lib_manager
         configmaps
-        # optional but still requires include header to be available if used
-        mars_scene_loader
-        mars_graphics
-        mars_gui
-        mars_sim
-        main_gui
         mars_interfaces
-        data_broker
+        mars_utils
         cfg_manager
-        data_broker_gui
-        cfg_manager_gui
-        lib_manager_gui
-        log_console
-        data_broker_plotter2
-        SkyDomePlugin
-        CameraGUI
-        entity_view
-        mars_smurf
-        mars_smurf_loader
+        # optional but still requires include header to be available if used
+        main_gui
 )
 include_directories(${PKGCONFIG_INCLUDE_DIRS})
 link_directories(${PKGCONFIG_LIBRARY_DIRS})

--- a/common/gui/gui_app/CMakeLists.txt
+++ b/common/gui/gui_app/CMakeLists.txt
@@ -21,6 +21,7 @@ CMAKE_USE_FULL_RPATH("${CMAKE_INSTALL_PREFIX}/lib")
 
 pkg_check_modules(PKGCONFIG
   lib_manager
+  configmaps
   cfg_manager
   main_gui
   mars_utils

--- a/common/gui/gui_app/manifest.xml
+++ b/common/gui/gui_app/manifest.xml
@@ -3,6 +3,7 @@
        foo
     </description>
 
+    <depend package="tools/configmaps" />
     <depend package="simulation/lib_manager" />
     <depend package="simulation/mars/common/gui/main_gui" />
     <depend package="simulation/mars/common/cfg_manager" />

--- a/entity_generation/entity_factory/CMakeLists.txt
+++ b/entity_generation/entity_factory/CMakeLists.txt
@@ -11,9 +11,11 @@ define_module_info()
 
 pkg_check_modules(PKGCONFIG REQUIRED
 			    lib_manager
+			    cfg_manager
 			    data_broker
 			    mars_interfaces
 			    configmaps
+			    mars_sim
 )
 include_directories(${PKGCONFIG_INCLUDE_DIRS})
 link_directories(${PKGCONFIG_LIBRARY_DIRS})

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -10,13 +10,14 @@ lib_defaults()
 define_module_info()
 
 #This adds base-lib to the package-config as dep.
-set(LIB_DEPS "base-lib")
 
 pkg_check_modules(PKGCONFIG REQUIRED
         configmaps
         data_broker
         mars_utils
 )
+set(LIB_DEPS "base-lib configmaps data_broker mars_utils")
+
 include_directories(${PKGCONFIG_INCLUDE_DIRS})
 link_directories(${PKGCONFIG_LIBRARY_DIRS})
 add_definitions(${PKGCONFIG_CLFAGS_OTHER})  #flags excluding the ones with -I

--- a/interfaces/mars_interfaces.pc.in
+++ b/interfaces/mars_interfaces.pc.in
@@ -7,7 +7,7 @@ Name: @PROJECT_NAME@
 Description: The DFKI Robot Simulator
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -l@PROJECT_NAME@
-Requires: mars_utils configmaps @LIB_DEPS@
+Requires: @LIB_DEPS@
 
 Cflags: -I${includedir} @MARS_CORE_EIGEN_DEFINITIONS@
 

--- a/plugins/CameraGUI/CMakeLists.txt
+++ b/plugins/CameraGUI/CMakeLists.txt
@@ -30,11 +30,12 @@ endif()
 setup_qt()
 
 pkg_check_modules(PKGCONFIG REQUIRED
-			    lib_manager
-			    mars_interfaces
+          lib_manager
+          mars_interfaces
           mars_graphics
           main_gui
           mars_sim
+          config_map_gui
 )
 include_directories(${PKGCONFIG_INCLUDE_DIRS})
 link_directories(${PKGCONFIG_LIBRARY_DIRS})

--- a/plugins/Text3D/CMakeLists.txt
+++ b/plugins/Text3D/CMakeLists.txt
@@ -12,6 +12,7 @@ define_module_info()
 include(CheckIncludeFileCXX)
 
 pkg_check_modules(PKGCONFIG REQUIRED
+			    cfg_manager
 			    lib_manager
 			    data_broker
 			    mars_interfaces

--- a/plugins/connectors/CMakeLists.txt
+++ b/plugins/connectors/CMakeLists.txt
@@ -10,12 +10,13 @@ define_module_info()
 
 
 pkg_check_modules(PKGCONFIG REQUIRED
-			    lib_manager
-			    data_broker
-			    mars_interfaces
-					mars_sim
-					mars_utils
-					configmaps
+			lib_manager
+			data_broker
+			mars_interfaces
+			mars_sim
+			mars_utils
+			configmaps
+			main_gui
 )
 include_directories(${PKGCONFIG_INCLUDE_DIRS})
 link_directories(${PKGCONFIG_LIBRARY_DIRS})

--- a/plugins/constraint_plugin/CMakeLists.txt
+++ b/plugins/constraint_plugin/CMakeLists.txt
@@ -11,6 +11,7 @@ define_module_info()
 
 pkg_check_modules(PKGCONFIG REQUIRED
         lib_manager
+        data_broker
         cfg_manager
         main_gui
         mars_interfaces

--- a/plugins/constraint_plugin/manifest.xml
+++ b/plugins/constraint_plugin/manifest.xml
@@ -1,12 +1,15 @@
 <package>
+    <name>constraint_plugin</name>
     <description brief="constraints_plugin">
       Plugin to create constraints between Nodes.
-   </description>
-	<maintainer>Matthias Goldhoorn/matthias@goldhoorn.eu</maintainer>
+    </description>
+    <maintainer>Matthias Goldhoorn/matthias@goldhoorn.eu</maintainer>
     <depend package="simulation/lib_manager" />
+    <depend package="simulation/mars/common/data_broker" />
     <depend package="simulation/mars/common/cfg_manager" />
     <depend package="simulation/mars/common/gui/main_gui" />
     <depend package="simulation/mars/interfaces" />
+    <depend package="tools/configmaps" />
     <tags>needs_opt</tags>
     <rosdep name="qt4" />
 </package>

--- a/scene_loader/CMakeLists.txt
+++ b/scene_loader/CMakeLists.txt
@@ -30,6 +30,7 @@ setup_qt()
 
 #Get linker and compiler flags from pkg-config
 pkg_check_modules(PKGCONFIG REQUIRED
+			    data_broker
 			    lib_manager
 			    minizip
 			    mars_utils

--- a/scene_loader/manifest.xml
+++ b/scene_loader/manifest.xml
@@ -2,11 +2,11 @@
     <description brief="mars_scene_loader">
        Plugin to load and save MARS scene files.
     </description>
-
-	<maintainer>Matthias Goldhoorn/matthias@goldhoorn.eu</maintainer>
+    <maintainer>Matthias Goldhoorn/matthias@goldhoorn.eu</maintainer>
     <depend package="simulation/lib_manager" />
     <depend package="simulation/mars/common/utils" />
     <depend package="simulation/mars/interfaces" />
+    <depend package="simulation/mars/common/data_broker" />
     <depend package="tools/configmaps" />
     <depend package="external/minizip" />
     <rosdep name="qt4" />


### PR DESCRIPTION
Building with separate package prefixes exposed multiple include issues,
resulting from incomplete dependencies given. This commit fixes these issues.