### PR TITLE
Compatibility to Ubuntu20.04

### DIFF
--- a/gui/configuration/mars_gui.pc.in
+++ b/gui/configuration/mars_gui.pc.in
@@ -6,7 +6,7 @@ includedir=${prefix}/include/
 Name: @PROJECT_NAME@
 Description: The DFKI Robot Simulator GUI
 Version: @PROJECT_VERSION@
-Requires.private: mars_interfaces lib_manager data_broker main_gui cfg_manager mars_graphics mars_sim opencv
+Requires.private: mars_interfaces lib_manager data_broker main_gui cfg_manager mars_graphics mars_sim opencv4
 Requires: @PUBLIC_DEPENDENCIES@
 Libs: -L${libdir} -l@PROJECT_NAME@
 


### PR DESCRIPTION
OpenCV's  Pkgconfig name changed to opencv4 in ubuntu 20.04. Changed mars_gui.pc.in accordingly.